### PR TITLE
Clean up unsafe write to USART TDR

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -288,7 +288,7 @@ impl<Usart, Tx, Rx> serial::Write<u8> for Serial<Usart, (Tx, Rx)>
 
     fn write(&mut self, byte: u8) -> nb::Result<(), Infallible> {
         if self.usart.isr.read().txe().bit_is_set() {
-            self.usart.tdr.write(|w| unsafe { w.tdr().bits(u16::from(byte)) });
+            self.usart.tdr.write(|w| w.tdr().bits(u16::from(byte)));
             Ok(())
         } else {
             Err(nb::Error::WouldBlock)


### PR DESCRIPTION
Accessing the USARTs TDR is safe again with stm32f3 0.13.2.