### PR TITLE
Make debug output with defmt depending on feature selection

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -389,6 +389,7 @@ macro_rules! adc_hal {
                     if !self.rb.cr.read().aden().is_enable() {
                         // Set ADEN=1
                         self.rb.cr.modify(|_, w| w.aden().enable());
+                        #[cfg(feature = "defmt")]
                         defmt::debug!("Wait for ready");
                         // Wait until ADRDY=1 (ADRDY is set after the ADC startup time). This can be
                         // done using the associated interrupt (setting ADRDYIE=1).


### PR DESCRIPTION
This fixes building _more-tests_ as a dependency of `stm32f3-discovery` which does not select the `defmt` feature.