### PR TITLE
Accept different errors in send_receive_wrong_baud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for GPIO output slew rate configuration ([#189])
 - Support for GPIO interrupts ([#189])
 - `ld` feature, which enables the memory.x generation ([#216])
-- Serial does now implement `embedded_hal::serial::{Read, Write}`. 
+- Serial does now implement `embedded_hal::serial::{Read, Write}`.
   No `split()` necessary. ([#212])
 - Serial can now listen for the `Idle` interrupt event ([#212])
 

--- a/README.md
+++ b/README.md
@@ -170,4 +170,5 @@ compile with older versions but that may change in any new patch release.
 
 ### Running Tests
 
-See [`testsuite/README.md`](testsuite/README.md) for how to set up and run tests on the target.
+See [`testsuite/README.md`](testsuite/README.md) for how to set up and run
+tests on the target.

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -12,7 +12,6 @@ Board in mind. They expect that several pins are wired together as hinted in
 
 ![test wiring](assets/test-wiring.jpg "Test Wiring for STM32F3Discovery")
 
-
 ## Running Tests
 
 Once you have set up the tooling and wired-up the board, you can execute the

--- a/testsuite/tests/uart.rs
+++ b/testsuite/tests/uart.rs
@@ -158,11 +158,12 @@ mod tests {
         defmt::info!("{}", c);
         assert!(matches!(c, Err(Error::Framing)));
 
-        // provoke an error (framing)
+        // provoke an error (this does not seem to be absolutely deterministic
+        // and we've seen multiple error variants in the wild)
         unwrap!(nb::block!(tx_fast.write(b'a')));
         let c = nb::block!(rx_slow.read());
         defmt::info!("{}", c);
-        assert!(matches!(c, Err(Error::Framing)));
+        assert!(matches!(c, Err(Error::Framing) | Err(Error::Noise)));
     }
 
     // TODO: Check the parity. But currently, there is no way to configure the parity


### PR DESCRIPTION
Even after unplugging my STM32F3DISCOVERY MB1035D for several hours, I'm getting a noise error in this test case. I'm using the wiring shown in [`testsuite/README.md`](https://github.com/Sh3Rm4n/stm32f3xx-hal/blob/a216cffb4e507e09f76c19c7708243dab38242dc/testsuite/README.md).
```
$ cargo test -p testsuite --test uart
    Finished test [unoptimized + debuginfo] target(s) in 0.06s
     Running tests/uart.rs (target/thumbv7em-none-eabihf/debug/deps/uart-03206c0e47367ea9)
  (HOST) INFO  flashing program (30.50 KiB)
  (HOST) INFO  success!
────────────────────────────────────────────────────────────────────────────────
         INFO  (1/3) running `test_many_baudrates`...
└─ uart::tests::__defmt_test_entry @ tests/uart.rs:35
         INFO  (2/3) running `send_receive_split`...
└─ uart::tests::__defmt_test_entry @ tests/uart.rs:35
         INFO  (3/3) running `send_receive_wrong_baud`...
└─ uart::tests::__defmt_test_entry @ tests/uart.rs:35
         INFO  Err(Framing)
└─ uart::tests::send_receive_wrong_baud @ tests/uart.rs:158
         INFO  Err(Noise)
└─ uart::tests::send_receive_wrong_baud @ tests/uart.rs:165
         INFO  all tests passed!
└─ uart::tests::__defmt_test_entry @ tests/uart.rs:35
────────────────────────────────────────────────────────────────────────────────
  (HOST) INFO  device halted without error
```

What about accepting just both error variants for peace of mind?